### PR TITLE
No Need of require active_merchant/billing/integrations

### DIFF
--- a/PayU/lib/active_merchant_payu_in.rb
+++ b/PayU/lib/active_merchant_payu_in.rb
@@ -1,5 +1,4 @@
 require 'active_merchant'
-require 'active_merchant/billing/integrations'
 require 'digest/sha2'
 require 'bigdecimal'
 


### PR DESCRIPTION
Active Merchant gem doesn't have active_merchant/billing/integrations file. It is throwing error while using this.